### PR TITLE
Feature：tic normalization

### DIFF
--- a/docs/en/normalization.md
+++ b/docs/en/normalization.md
@@ -1,0 +1,183 @@
+# MassFlow
+
+This document introduces the normalization module in MassFlow, focusing on the unified entry `MSIPreprocessor.normalization_spectrum` and helper functions defined in `preprocess/normalizer_helper.py`. It provides an overview, API specification, example code, parameter notes, and troubleshooting tips.
+
+## Overview
+- Input and output
+  - Input: `module.ms_module.SpectrumBaseModule` (with 1D `intensity` and optional `mz_list`)
+  - Output: A new `SpectrumBaseModule` with the same `mz_list` and coordinates; `intensity` is replaced by normalized (and optionally scaled) values.
+- Methods
+  - TIC (Total Ion Current) normalization: scales intensities such that the sum equals 1.
+  - Median normalization: scales intensities such that the median equals 1.
+- Additional scaling
+  - `scale_method` supports:
+    - `'none'`: no extra scaling
+    - `'unit'`: min-max scaling to `[0, 1]` 
+
+### Function Relationship Diagram
+
+```mermaid
+graph LR
+
+  A[MSIPreprocessor.normalization_spectrum] --> B{Primary Method}
+  B --> C[TIC]
+  B --> D[Median]
+  C --> E[Apply Scaling 'none'/'unit' ]
+  D --> E
+  E --> F[Return Spectrum with normalized intensity]
+```
+
+## Core API
+
+### MSIPreprocessor.normalization_spectrum
+
+```python
+preprocess.ms_preprocess.MSIPreprocessor.normalization_spectrum(
+  data: SpectrumBaseModule | SpectrumImzML,
+  scale_method: str = "none",
+  method: str = "tic"
+) -> SpectrumBaseModule | SpectrumImzML
+```
+
+- Description: Unified entry for spectrum normalization. Dispatches to TIC or median normalization and optionally applies post-scaling. Returns a spectrum object preserving `mz_list` and coordinates, with normalized `intensity`.
+- Supported `method`s:
+  - `'tic'`, `'total_ion_current'` (sum equals 1)
+  - `'median'` (median equals 1)
+- Supported `scale_method`s:
+  - `'none'` (no extra scaling)
+  - `'unit'` (min-max scaling to `[0, 1]`)
+- Returns: A new `SpectrumBaseModule` (or `SpectrumImzML`) instance, preserving `mz_list` and coordinates.
+- Exceptions:
+  - `ValueError`: Unsupported `method`, or invalid TIC/median (≤ 0) in helper functions.
+
+### Helper functions (preprocess/normalizer_helper.py)
+
+- `tic_normalize(intensity, scale_method='none') -> np.ndarray`  
+  Scales the array by its sum; raises `ValueError` if sum ≤ 0. Optionally applies min-max scaling.
+- `median_normalize(intensity, scale_method='none') -> np.ndarray`  
+  Scales the array by its median; raises `ValueError` if median ≤ 0. Optionally applies min-max scaling.
+- `apply_scaling(intensity, scale_method) -> np.ndarray`  
+  `'none'` or `'unit'` min-max scaling to `[0, 1]`.
+- `normalizer(intensity, scale_method='none', method='tic') -> np.ndarray`  
+  Dispatcher to TIC or median normalization with validation.
+
+## Examples
+
+### TIC normalization (after Savitzky-Golay denoising)
+
+```python
+import sys
+import os
+import numpy as np
+from module.ms_module import MS
+from module.ms_data_manager_imzml import MSDataManagerImzML
+from preprocess.ms_preprocess import MSIPreprocessor
+from tools.plot import plot_spectrum
+
+FILE_PATH = "data\\neg-gz4.imzML"
+ms = MS()
+ms_md = MSDataManagerImzML(ms, filepath=FILE_PATH, coordinates_zero_based=False)
+ms_md.load_full_data_from_file()
+sp = ms[0]
+# Denoise then normalize
+denoised = MSIPreprocessor.noise_reduction(
+    data=sp,
+    method="savgol",
+    window=11,
+    polyorder=3
+)
+normalized_tic = MSIPreprocessor.normalization_spectrum(
+    data=denoised,
+    method="tic",
+    scale_method="none"
+)
+
+tic_origin = float(np.sum(denoised.intensity))
+tic_after = float(np.sum(normalized_tic.intensity))
+print(f"TIC normalized sum={tic_after:.6f}")
+
+plot_spectrum(
+    base = denoised,
+    mz_range=(500.0, 510.0),
+    intensity_range=(0.0, 1.5),
+    title_suffix='Savgol_denoised'
+)
+
+plot_spectrum(
+    base=normalized_tic,
+    mz_range=(500.0, 510.0),
+    intensity_range=(0.0, 1.5 / tic_origin),
+    title_suffix='TIC_normalized_none'
+)
+```
+![Original Spectrum after denoised]()
+![TIC example]()
+
+### Median normalization (after Savitzky-Golay denoising)
+```python
+denoised = MSIPreprocessor.noise_reduction(
+    data=sp,
+    method="savgol",
+    window=11,
+    polyorder=3
+)
+med_origin = float(np.median(denoised.intensity))
+normalized_med = MSIPreprocessor.normalization_spectrum(
+    data=denoised,
+    method="median",
+    scale_method="none"
+)
+med_after = float(np.median(normalized_med.intensity))
+print(f"Median_value_after={med_after:.6f}")
+
+plot_spectrum(
+    base=normalized_med,
+    mz_range=(500.0, 510.0),
+    intensity_range=(0.0, 1.5 / med_origin),
+    title_suffix='Median_normalized_none'
+)
+```
+![Median example]()
+
+### Optional 0–1 scaling (unit scaling)
+
+```python
+normalized_unit = MSIPreprocessor.normalization_spectrum(
+    data=denoised,
+    method="tic",          # or "median"
+    scale_method="unit"    # min-max scaling to [0, 1]
+)
+plot_spectrum(
+        base = normalized_tic,
+        mz_range=(500.0, 510.0),
+        intensity_range=(0.0, 0.1),
+        title_suffix='TIC_normalized_unit'     
+    )
+```
+![TIC example unit scaling]()
+
+- Use `'unit'` to scale the normalized intensity to `[0, 1]` for consistent visualization/comparison across spectra.
+
+## Parameters and Tuning
+- General
+  - Choose `'tic'` for consistent total intensity across pixels; suitable for visualization, relative quantitation.
+  - Choose `'median'` to reduce the influence of extreme values; robust for noisy spectra.
+  - Use `'unit'` scaling for plotting or UI normalization; avoid if you need numeric properties like sum=1 or median=1 to remain interpretable.
+- TIC
+  - Sensitive to large peaks; consider prior denoising/baseline correction.
+- Median
+  - More robust against heavy-tailed distributions; preserves rank structure.
+
+## Troubleshooting
+- `ValueError: TIC value is not greater than 0`  
+  Ensure the spectrum has non-zero sum after preprocessing; avoid using entirely empty or clipped spectra.
+- `ValueError: Median value is not greater than 0`  
+  Ensure intensities are not all zero; consider baseline correction or avoiding aggressive clipping.
+- Unsupported method or scale_method  
+  Check spelling: `method='tic'|'median'`, `scale_method='none'|'unit'`.
+
+## References
+- `preprocess/normalizer_helper.py` (TIC/median implementations and scaling)
+- `preprocess/ms_preprocess.py` (Unified entry point and parameter dispatch)
+- `module/ms_module.py` (Data structure for `SpectrumBaseModule`)
+- `tools/plot.py` (Plotting utilities for `SpectrumBaseModule`)

--- a/docs/en/normalization.md
+++ b/docs/en/normalization.md
@@ -41,7 +41,7 @@ preprocess.ms_preprocess.MSIPreprocessor.normalization_spectrum(
 
 - Description: Unified entry for spectrum normalization. Dispatches to TIC or median normalization and optionally applies post-scaling. Returns a spectrum object preserving `mz_list` and coordinates, with normalized `intensity`.
 - Supported `method`s:
-  - `'tic'`, `'total_ion_current'` (sum equals 1)
+  - `'tic'` (sum equals 1)
   - `'median'` (median equals 1)
 - Supported `scale_method`s:
   - `'none'` (no extra scaling)
@@ -80,7 +80,7 @@ ms_md = MSDataManagerImzML(ms, filepath=FILE_PATH, coordinates_zero_based=False)
 ms_md.load_full_data_from_file()
 sp = ms[0]
 # Denoise then normalize
-denoised = MSIPreprocessor.noise_reduction(
+denoised = MSIPreprocessor.noise_reduction_spectrum(
     data=sp,
     method="savgol",
     window=11,
@@ -115,7 +115,7 @@ plot_spectrum(
 
 ### Median normalization (after Savitzky-Golay denoising)
 ```python
-denoised = MSIPreprocessor.noise_reduction(
+denoised = MSIPreprocessor.noise_reduction_spectrum(
     data=sp,
     method="savgol",
     window=11,
@@ -148,7 +148,7 @@ normalized_unit = MSIPreprocessor.normalization_spectrum(
     scale_method="unit"    # min-max scaling to [0, 1]
 )
 plot_spectrum(
-        base = normalized_tic,
+        base = normalized_unit,
         mz_range=(500.0, 510.0),
         intensity_range=(0.0, 0.1),
         title_suffix='TIC_normalized_unit'     

--- a/preprocess/ms_preprocess.py
+++ b/preprocess/ms_preprocess.py
@@ -144,7 +144,7 @@ class MSIPreprocessor:
             (propagated from the lower-level normalizer).
         """
         intensity = data.intensity
-        index = data.mz_list
+ 
 
         norm_intensity = normalizer(
             intensity,

--- a/preprocess/ms_preprocess.py
+++ b/preprocess/ms_preprocess.py
@@ -144,8 +144,6 @@ class MSIPreprocessor:
             (propagated from the lower-level normalizer).
         """
         intensity = data.intensity
- 
-
         norm_intensity = normalizer(
             intensity,
             scale_method=scale_method,

--- a/preprocess/normalizer_helper.py
+++ b/preprocess/normalizer_helper.py
@@ -8,7 +8,7 @@ def _input_validation(
     intensity:np.ndarray,
     index: Optional[np.ndarray] = None):
     """
-    Validate input parameters for smoothing functions.
+    Validate input parameters for normalization functions.
     
     Parameters:
         intensity (np.ndarray): 1D intensity array to be preprocessed.
@@ -124,8 +124,8 @@ def apply_scaling(
         if intensity_max - intensity_min > 0:
             return (intensity - intensity_min) / (intensity_max - intensity_min)
         else:
-            # If all values are the same, keep original
-            return np.zeros_like(intensity)
+        # If all values are the same, return original values
+            return intensity
         
     else:
         logger.error(f"Unsupported scale_method: {scale_method}. "
@@ -160,7 +160,7 @@ def normalizer(intensity: np.ndarray,
     if method == "tic":
         return tic_normalize(intensity, scale_method=scale_method)
     elif method == "median":
-        return  median_normalize(intensity, scale_method=scale_method)
+        return median_normalize(intensity, scale_method=scale_method)
     else:
         supported = "tic, median"
         logger.error(f"Unsupported normalization method: {method}. Use one of: {supported}.")

--- a/preprocess/normalizer_helper.py
+++ b/preprocess/normalizer_helper.py
@@ -1,8 +1,5 @@
-from datetime import date
 import numpy as np
 from typing import Optional
-from module.ms_module import SpectrumBaseModule
-from typing import Union
 from logger import get_logger
 
 logger = get_logger(__name__)

--- a/preprocess/normalizer_helper.py
+++ b/preprocess/normalizer_helper.py
@@ -1,0 +1,170 @@
+from datetime import date
+import numpy as np
+from typing import Optional
+from module.ms_module import SpectrumBaseModule
+from typing import Union
+from logger import get_logger
+
+logger = get_logger(__name__)
+
+def _input_validation(
+    intensity:np.ndarray,
+    index: Optional[np.ndarray] = None):
+    """
+    Validate input parameters for smoothing functions.
+    
+    Parameters:
+        intensity (np.ndarray): 1D intensity array to be preprocessed.
+        index (Optional[np.ndarray]): 1D index array (e.g., m/z values). If None, 
+            will be generated as np.arange(len(intensity)).
+    
+    Raises:
+        TypeError: If intensity is not a numpy array.
+        ValueError: If intensity is not 1D or empty.
+    """
+    # Validate intensity array
+    if intensity is None:
+        logger.error("intensity must be a numpy array")
+        raise TypeError("intensity must be a numpy array")
+
+    elif intensity.ndim != 1 or intensity.size == 0:
+        logger.error("intensity must be a non-empty 1D array")
+        raise ValueError("intensity must be a non-empty 1D array")
+
+    if index is not None and (index.ndim != 1 or index.size != intensity.size):
+        logger.error("index must be a 1D array with the same length as intensity")
+        raise ValueError("index must be a 1D array with the same length as intensity")
+
+def tic_normalize(
+        intensity: np.ndarray,
+        scale_method: str = 'none'
+):
+    """
+    Total Ion Current (TIC) normalization.
+
+    Parameters:
+        intensity (np.ndarray): Input 1D intensity array.
+        scale_method (str): Optional scaling after normalization:
+            - 'none': no additional scaling
+            - 'unit': min-max scale to [0, 1]
+
+    Returns:
+        np.ndarray: TIC-normalized intensity array. Sum equals 1 when input sum > 0.
+
+    Raises:
+        ValueError: If TIC (sum of intensity) is not greater than 0.
+    """
+    tic = float(np.sum(intensity))
+    # Apply TIC normalization
+    if tic > 0.0:
+        norm_intensity = intensity / tic
+    else:
+        logger.error("TIC value is not greater than 0, cannot normalize data")
+        raise ValueError("TIC value is not greater than 0, cannot normalize data")
+    # Apply scaling method
+    norm_intensity = apply_scaling(norm_intensity, scale_method)
+    
+    return norm_intensity
+
+def median_normalize(
+        intensity: np.ndarray,
+        scale_method: str = 'none'
+):
+    """
+    Median normalization.
+
+    Parameters:
+        intensity (np.ndarray): Input 1D intensity array.
+        scale_method (str): Optional scaling after normalization:
+            - 'none': no additional scaling
+            - 'unit': min-max scale to [0, 1]
+
+    Returns:
+        np.ndarray: Median-normalized intensity array. Median equals 1 when input median > 0.
+
+    Raises:
+        ValueError: If median of intensity is not greater than 0.
+    """
+    med = float(np.median(intensity))
+    # Apply median normalization
+    if med > 0.0:
+        norm_intensity = intensity / med
+    else:
+        logger.error("Median value is not greater than 0, cannot normalize data")
+        raise ValueError("Median value is not greater than 0, cannot normalize data")
+    # Apply scaling method
+    norm_intensity = apply_scaling(norm_intensity, scale_method)
+    
+    return norm_intensity
+
+def apply_scaling(
+        intensity: np.ndarray,
+        scale_method: str
+):
+    """
+    Apply scaling transformation to intensity data.
+
+    Parameters:
+        intensity (np.ndarray): Input intensity array after primary normalization.
+        scale_method (str): Scaling method to apply:
+                          - 'none': No additional scaling
+                          - 'unit': Scale to 0-1 range using min-max normalization
+
+    Returns:
+        np.ndarray: Scaled intensity array.
+
+    Raises:
+        ValueError: If scale_method is not supported.
+    """
+    if scale_method == 'none':
+        return intensity
+    elif scale_method == 'unit':
+        # Min-max scaling to [0, 1] range
+        if intensity.size == 0:
+            return intensity
+        intensity_min = np.min(intensity)
+        intensity_max = np.max(intensity)
+        if intensity_max - intensity_min > 0:
+            return (intensity - intensity_min) / (intensity_max - intensity_min)
+        else:
+            # If all values are the same, keep original
+            return np.zeros_like(intensity)
+        
+    else:
+        logger.error(f"Unsupported scale_method: {scale_method}. "
+                        f"Supported methods are: 'none', 'unit'")
+        raise ValueError(f"Unsupported scale_method: {scale_method}. "
+                        f"Supported methods are: 'none', 'unit'")
+
+def normalizer(intensity: np.ndarray,
+               scale_method: str = 'none',
+               method: str = "tic"):
+    """
+    Unified normalization dispatcher.
+
+    Parameters:
+        intensity (np.ndarray): Input 1D intensity array.
+        scale_method (str): Optional scaling after normalization:
+            - 'none': no additional scaling
+            - 'unit': min-max scale to [0, 1]
+        method (str): Primary normalization method:
+            - 'tic': Total Ion Current normalization
+            - 'median': Median normalization
+
+    Returns:
+        np.ndarray: Normalized (and optionally scaled) intensity array.
+
+    Raises:
+        ValueError: If `method` is not supported.
+    """
+    # # Basic validation
+    _input_validation(intensity)
+    # Choose normalization method
+    if method == "tic":
+        return tic_normalize(intensity, scale_method=scale_method)
+    elif method == "median":
+        return  median_normalize(intensity, scale_method=scale_method)
+    else:
+        supported = "tic, median"
+        logger.error(f"Unsupported normalization method: {method}. Use one of: {supported}.")
+        raise ValueError(f"Unknown normalization method: {method}")


### PR DESCRIPTION
实现质谱归一化功能并添加文档

新增normalizer_helper.py模块，提供TIC和中位数归一化方法，支持可选缩放

扩展MSIPreprocessor.normalization_spectrum接口支持多种归一化方式

添加详细使用文档normalization.md说明功能及示例

移除未使用的导入并清理冗余代码

删除normalizer_helper.py中未使用的datetime和SpectrumBaseModule导入

清理ms_preprocess.py中未使用的index变量